### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,5 +37,5 @@
 
 ## 使用(Install)
 引入方式有两种：
-* 安装有Cocoapods的朋友可以直接  pod 'GWPKit'
-* 没有安装过Cocoapods的朋友可以download下整个zip文件，解压后里面有一个GWPKit文件夹，整个导入即可。但是GWPKit有对MBProgressHUD的封装，所以对他有封装，如果项目中没有引入MBProgressHUD可能会报错。
+* 安装有CocoaPods的朋友可以直接  pod 'GWPKit'
+* 没有安装过CocoaPods的朋友可以download下整个zip文件，解压后里面有一个GWPKit文件夹，整个导入即可。但是GWPKit有对MBProgressHUD的封装，所以对他有封装，如果项目中没有引入MBProgressHUD可能会报错。


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
